### PR TITLE
Add support for incremented namespaces per token

### DIFF
--- a/backends/backend.go
+++ b/backends/backend.go
@@ -13,6 +13,7 @@ type Backend interface {
 	CreateSchema() error
 	DropSchema() error
 	CreateToken(token string) error
+	IncrementAndGetNamespacedToken(token string, namespace string) (int64, error)
 	IncrementAndGetToken(token string) (int64, error)
 }
 

--- a/inc_test.go
+++ b/inc_test.go
@@ -127,3 +127,46 @@ func TestPutOnNewTokenShouldIncrementValue(t *testing.T) {
 	}
 
 }
+
+func TestPutOnNewNamespaceShouldIncrementFromZero(t *testing.T) {
+	resetDatabase(t)
+	req, err := http.NewRequest("POST", "http://localhost/new", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	response := httptest.NewRecorder()
+	app.ServeHTTP(response, req)
+
+	if response.Code != 201 {
+		t.Fatalf("Incorrect status code: expected %v, actual %v", 201, response.Code)
+	}
+
+	token := response.Body.String()
+	req, err = http.NewRequest("PUT", "http://localhost/"+token+"/1.0", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	response = httptest.NewRecorder()
+	app.ServeHTTP(response, req)
+
+	if response.Code != 200 {
+		t.Fatalf("Incorrect status code: expected %v, actual %v", 200, response.Code)
+	}
+
+	if response.Body.String() != "0" {
+		t.Fatalf("Incorrect initial token value: expected %v, actual %v", "0", response.Body.String())
+	}
+
+	response = httptest.NewRecorder()
+	app.ServeHTTP(response, req)
+
+	if response.Code != 200 {
+		t.Fatalf("Incorrect status code: expected %v, actual %v", 200, response.Code)
+	}
+
+	if response.Body.String() != "1" {
+		t.Fatalf("Counter value did not increment: expected %v, actual %v", "1", response.Body.String())
+	}
+}


### PR DESCRIPTION
Adds an additional endpoint to allow for PUT'ing to arbitrary namespaces on a token and getting the counter back. This is currently useful for reseting the patch version to zero when bumping a major/minor version of a semantic version. It's generic enough though that it's probably useful for other things?

Ex -

```
➜  ~ http POST http://localhost:8080/new                                
HTTP/1.1 201 Created
Content-Length: 32
Content-Type: text/plain; charset=utf-8
Date: Thu, 30 Mar 2017 18:31:06 GMT

47844f0d40b66f2c0217a9a506a3e464
```
```
➜  ~ http PUT http://localhost:8080/47844f0d40b66f2c0217a9a506a3e464/1.2
HTTP/1.1 200 OK
Content-Length: 1
Content-Type: text/plain; charset=utf-8
Date: Thu, 30 Mar 2017 18:31:18 GMT

0

➜  ~ http PUT http://localhost:8080/47844f0d40b66f2c0217a9a506a3e464/1.2
HTTP/1.1 200 OK
Content-Length: 1
Content-Type: text/plain; charset=utf-8
Date: Thu, 30 Mar 2017 18:31:19 GMT

1
```